### PR TITLE
変形技のクールダウン実装のため、_shiftCooldown、_isInShiftCooldownフィールドおよび各プロパティを追加。

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -887,6 +887,7 @@ MonoBehaviour:
   - {fileID: 159084274}
   _hitPoint: 100
   _speed: 5
+  _shiftCooldown: 5
   _slowDownRate: 0.5
 --- !u!1 &907236227
 GameObject:

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -67,6 +67,23 @@ public class Player : MonoBehaviour
     private float _speed;
 
     [SerializeField]
+    private float _shiftCooldown;
+
+    public float ShiftCooldown
+    {
+        get {return _shiftCooldown;}
+        set {_shiftCooldown = value;}
+    }
+
+    private bool _isInShiftCooldown;
+
+    public bool IsInShiftCooldown
+    {
+        get {return _isInShiftCooldown;}
+        set {_isInShiftCooldown = value;}
+    }   
+
+    [SerializeField]
     private float _slowDownRate;
 
     private bool _isSlowingDown;
@@ -81,6 +98,13 @@ public class Player : MonoBehaviour
     void Start()
     {
         MyShape = _ownShapes[0];
+
+        CurrentEnemy = null;
+
+        Direction = Vector2.zero;
+
+        IsInShiftCooldown = false;
+        IsSlowingDown = false;
 
         //プレイエリアの角を取得
         _corners = new Vector3[4];
@@ -182,9 +206,33 @@ public class Player : MonoBehaviour
 
         Debug.Log($"ShiftShape {mode}");
 
+        if(MyShape == _ownShapes[mode])
+        {
+            Debug.Log("Shifting to same shape");
+            return;
+        }
+
+        if(IsInShiftCooldown)
+        {
+            return;
+        }
+
         MyShape = _ownShapes[mode];
 
         MyShape.ShiftSkill();
+
+        StartCoroutine(StartShiftCooldown());
+    }
+
+    private IEnumerator StartShiftCooldown()
+    {
+        Debug.Log("Start ShiftCooldown");
+        IsInShiftCooldown = true;
+
+        yield return new WaitForSeconds(ShiftCooldown);
+
+        Debug.Log("Finish ShiftCooldown");
+        IsInShiftCooldown = false;
     }
 
     private void _ShiftShapeOfColliders(PlayerShape pShape)


### PR DESCRIPTION
初期化し損ねていたフィールドをStartメソッドで初期化。現状態と同じ形に変形できないよう_ShiftShapeメソッドを変更。クールダウン中は変形できないよう変更。クールダウン実装のため、StartShiftCooldownメソッドを追加。シーン上でプレイヤーの変形クールダウンを設定。