### PR TITLE
HPバーとGrazeCount周りのメンバ名の調整。Player内のPrimaryAttackCostを削除。PrimaryAttackの…

### DIFF
--- a/Assets/Prefabs/PlayerShapes/Shape_Circle.prefab
+++ b/Assets/Prefabs/PlayerShapes/Shape_Circle.prefab
@@ -49,3 +49,4 @@ MonoBehaviour:
   _primaryAttackCost: 100
   _primaryAttackDamage: 5
   _destroyField: {fileID: 8351723773996737352, guid: d5c685b4036fcce429537a739c92bbce, type: 3}
+  _specialSkillCost: 500

--- a/Assets/Prefabs/PlayerShapes/Shape_Square.prefab
+++ b/Assets/Prefabs/PlayerShapes/Shape_Square.prefab
@@ -49,3 +49,4 @@ MonoBehaviour:
   _primaryAttackCost: 120
   _primaryAttackDamage: 3
   _destroyField: {fileID: 8351723773996737352, guid: 3f2df12ca171f9d488ae031c030831de, type: 3}
+  _specialSkillCost: 300

--- a/Assets/Prefabs/PlayerShapes/Shape_Triangle.prefab
+++ b/Assets/Prefabs/PlayerShapes/Shape_Triangle.prefab
@@ -49,3 +49,4 @@ MonoBehaviour:
   _primaryAttackCost: 50
   _primaryAttackDamage: 2
   _destroyField: {fileID: 8351723773996737352, guid: 7dca6a5add47f924496ddc68f1536db7, type: 3}
+  _specialSkillCost: 300

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -706,6 +706,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _player: {fileID: 691294819}
+  _specialGrazeBar: {fileID: 589313743}
 --- !u!1 &595751805
 GameObject:
   m_ObjectHideFlags: 0
@@ -1065,7 +1066,6 @@ MonoBehaviour:
   _shiftCooldown: 5
   _slowDownRate: 0.5
   _maxHitPoint: 100
-  _playerSpecialGrazeBar: {fileID: 589313744}
 --- !u!1 &907236227
 GameObject:
   m_ObjectHideFlags: 0
@@ -1762,6 +1762,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _player: {fileID: 691294819}
+  _primaryGrazeBarSlider: {fileID: 1338443249}
 --- !u!1 &1364362301
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GrazeCollider.cs
+++ b/Assets/Scripts/GrazeCollider.cs
@@ -22,7 +22,8 @@ public class GrazeCollider : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        _player.GrazeCounter += GrazeCount;
+        _player.PrimaryGrazeCount += GrazeCount;
+        _player.SpecialGrazeCount += GrazeCount;
     }
 
     public void OnTriggerEnter2D(Collider2D collider)

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -16,6 +16,10 @@ public class Player : MonoBehaviour
 
     private PlayerHpBar _playerHpBar;
 
+    private PlayerPrimaryGrazeBar _playerPrimaryGrazeBar;
+
+    private PlayerSpecialGrazeBar _playerSpecialGrazeBar;
+
     private Vector3[] _corners;
 
     [SerializeField]
@@ -29,6 +33,11 @@ public class Player : MonoBehaviour
         set
         {
             _hitPoint = Mathf.Clamp(value, 0, MaxHitPoint);
+
+            if(_playerHpBar == null)
+            {
+                _playerHpBar = GameObject.Find("PlayerHpBar").GetComponent<PlayerHpBar>();
+            }
             _playerHpBar.UpdateHp();
         }
     }
@@ -91,14 +100,7 @@ public class Player : MonoBehaviour
         get {return _isSlowingDown;}
         set {_isSlowingDown = value;}
     }    
-    
-    private int _PrimaryAttackCost;
 
-    public int PrimaryAttackCost
-    {
-        get {return _PrimaryAttackCost;}
-        set {_PrimaryAttackCost = value;}
-    }
     private int _money = 0;
 
     public int Money
@@ -124,21 +126,45 @@ public class Player : MonoBehaviour
         set {_maxHitPoint = value;}
     }
 
-    private int _grazeCounter;
+    private int _primaryGrazeCount;
 
-    public int GrazeCounter
+    public int PrimaryGrazeCount
     {
-        get {return _grazeCounter;}
-        set {_grazeCounter = value;}
+        get {return _primaryGrazeCount;}
+        set 
+        {
+            _primaryGrazeCount = value;
+
+            if(PrimaryGrazeCount >= MyShape.PrimaryAttackCost)
+            {
+                PrimaryAttack();
+            }
+
+            if(_playerPrimaryGrazeBar == null)
+            {
+                _playerPrimaryGrazeBar = GameObject.Find("PlayerPrimaryGrazeBar").GetComponent<PlayerPrimaryGrazeBar>();
+            }
+            _playerPrimaryGrazeBar.UpdatePrimaryGrazeCount();  
+        }
     }
 
-    private int _specialGrazeCounter;
-    public int SpecialGrazeCounter
+    private int _specialGrazeCount;
+
+    public int SpecialGrazeCount
     {
-        get {return _specialGrazeCounter;}
-        set {_specialGrazeCounter = value;}
+        get {return _specialGrazeCount;}
+        set
+        {
+            _specialGrazeCount = value;
+
+            if(_playerSpecialGrazeBar == null)
+            {
+                _playerSpecialGrazeBar = GameObject.Find("PlayerSpecialGrazeBar").GetComponent<PlayerSpecialGrazeBar>();
+            }
+            _playerSpecialGrazeBar.UpdateSpecialGrazeCount();
+        }
     }
-    
+
     private float _expansionValue;
 
     public float ExpansionValue
@@ -150,26 +176,13 @@ public class Player : MonoBehaviour
             }
     }
 
-    [SerializeField]
-    private PlayerSpecialGrazeBar _playerSpecialGrazeBar;
-
-    private int _specialGrazeCount;
-
-    public int SpecialGrazeCount
-    {
-        get {return _specialGrazeCount;}
-        set {_specialGrazeCount = value;}
-    }
-
     // Start is called before the first frame update
     void Start()
     {
-        _playerHpBar = GameObject.Find("PlayerHpBar").GetComponent<PlayerHpBar>();
-
-        GrazeCounter = 0;
-
-        PrimaryAttackCost = 500;
         MyShape = _ownShapes[0];
+
+        PrimaryGrazeCount = 0;
+        SpecialGrazeCount = 0;
 
         CurrentEnemy = null;
 
@@ -192,11 +205,6 @@ public class Player : MonoBehaviour
     void Update()
     {
         _Move();
-
-        if(GrazeCounter >= PrimaryAttackCost){
-            PrimaryAttack();
-        }
-    
     }
 
     // 方向入力を受ける関数
@@ -259,7 +267,7 @@ public class Player : MonoBehaviour
     public void PrimaryAttack()
     {
         // Debug.Log($"Attack {MyShapeNumber}");
-        GrazeCounter -= PrimaryAttackCost;
+        PrimaryGrazeCount -= MyShape.PrimaryAttackCost;
     }
 
     //変形入力を受ける関数
@@ -268,7 +276,6 @@ public class Player : MonoBehaviour
         if(context.performed)
         {
             _ShiftShape(0);
-            PrimaryAttackCost = 100;
         }
     }
 
@@ -277,7 +284,6 @@ public class Player : MonoBehaviour
         if(context.performed)
         {
             _ShiftShape(1);
-            PrimaryAttackCost = 500;
         }
     }
 
@@ -286,7 +292,6 @@ public class Player : MonoBehaviour
         if(context.performed)
         {
             _ShiftShape(2);
-            PrimaryAttackCost = 1000;
         }
     }
 
@@ -326,15 +331,15 @@ public class Player : MonoBehaviour
 
     private void _SpecialSkill()
     {
-        if (SpecialGrazeCounter < MyShape.SpecialSkillCost)
+        if (SpecialGrazeCount < MyShape.SpecialSkillCost)
         {
-            Debug.Log($"SpecialGrazeCounter < MyShape.SpecialSkillCost");
+            Debug.Log($"SpecialGrazeCount < MyShape.SpecialSkillCost");
             return;
         }
 
         MyShape.SpecialSkill();
 
-        SpecialGrazeCounter = 0;
+        SpecialGrazeCount = 0;
     }
 
     private IEnumerator StartShiftCooldown()

--- a/Assets/Scripts/PlayerPrimaryGrazeBar.cs
+++ b/Assets/Scripts/PlayerPrimaryGrazeBar.cs
@@ -8,13 +8,13 @@ public class PlayerPrimaryGrazeBar : MonoBehaviour
     [SerializeField]
     private Player _player;
 
-    private Slider _primaryGrazeBar;
+    [SerializeField]
+    private Slider _primaryGrazeBarSlider;
 
     // Start is called before the first frame update
     void Start()
     {
-        _primaryGrazeBar = GameObject.Find("PlayerPrimaryGrazeBar").GetComponent<Slider>();
-        UpdatePrimaryGrazeCount();
+
     }
 
     // Update is called once per frame
@@ -25,6 +25,6 @@ public class PlayerPrimaryGrazeBar : MonoBehaviour
 
     public void UpdatePrimaryGrazeCount()
     {
-        _primaryGrazeBar.value = (float)100/*_player.PrimaryGrazeCount*//(float)_player.MyShape.PrimaryAttackCost;
+        _primaryGrazeBarSlider.value = (float)_player.PrimaryGrazeCount / (float)_player.MyShape.PrimaryAttackCost;
     }
 }

--- a/Assets/Scripts/PlayerSpecialGrazeBar.cs
+++ b/Assets/Scripts/PlayerSpecialGrazeBar.cs
@@ -8,13 +8,13 @@ public class PlayerSpecialGrazeBar : MonoBehaviour
     [SerializeField]
     private Player _player;
 
+    [SerializeField]
     private Slider _specialGrazeBar;
 
     // Start is called before the first frame update
     void Start()
     {
-        _specialGrazeBar = GameObject.Find("PlayerSpecialGrazeBar").GetComponent<Slider>();
-        UpdateSpecialGrazeCount();
+
     }
 
     // Update is called once per frame
@@ -25,6 +25,6 @@ public class PlayerSpecialGrazeBar : MonoBehaviour
 
     public void UpdateSpecialGrazeCount()
     {
-        _specialGrazeBar.value = (float)_player.SpecialGrazeCount/(float)100/*_player.MyShape.SpecialSkillCost*/;
+        _specialGrazeBar.value = (float)_player.SpecialGrazeCount / (float)_player.MyShape.SpecialSkillCost;
     }
 }


### PR DESCRIPTION
…値チェックをプロパティ内に変更。各形のSpecialSkillCostをアタッチ。Startの初期化順を変更。GrazeBarのテスト文を実際の値に変更。GrazeBarのStartの内容を削除。

かなり既存のコードをいろいろいじったので、今後の処理に影響が出る可能性大。